### PR TITLE
removed audio and added a randomised gap size between pipes

### DIFF
--- a/assets.py
+++ b/assets.py
@@ -22,4 +22,5 @@ def load_audios():
 
 
 def play_audio(name):
-    audios[name].play()
+    #audios[name].play()
+    pass

--- a/objects/column.py
+++ b/objects/column.py
@@ -10,7 +10,7 @@ from layer import Layer
 class Column(pygame.sprite.Sprite):
     def __init__(self, *groups):
         self._layer = Layer.OBSTACLE
-        self.gap = 100
+        self.gap = 80 + random.randint(0, 50) # Add randomness to gap
 
         self.sprite = assets.get_sprite("pipe-green")
         self.sprite_rect = self.sprite.get_rect()


### PR DESCRIPTION
Bypass the audio function to not play any sounds
Made the gap between pipes now random between 80 to 130 units instead of being fixed at 100